### PR TITLE
Perceived performance tweak

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -89,7 +89,7 @@
     <div class="visualizations text-center">
       <h1>Explore</h1>
       <div class="relative">
-        <div class="scroll-to-view">Scroll to view visualizations.</div>
+        <div class="scroll-to-view">Loading visualizations...</div>
         <div class="iframe-wrapper">
           <iframe
             src=""

--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -3,7 +3,7 @@
     visualizations: {
       domain: 'https://app.periscopedata.com',
       dashboards: {
-        desktop: '4dff3c25-3a2d-4466-955c-3f3638b89fb9',
+        desktop: 'e12a39cb-63d2-4349-94a1-d0ebc6bf9a7d',
         mobile: '171d3869-a831-433b-900d-45e53badfd7f',
       },
       constants: {

--- a/app/scripts/sections/visualizations.js
+++ b/app/scripts/sections/visualizations.js
@@ -1,9 +1,9 @@
 (function() {
   let loaded = false;
 
-  window.addEventListener('scroll', loadDashboard);
   window.addEventListener('resize-complete', reflowDashboard);
   window.addEventListener('message', messageHandler);
+  loadDashboard();
 
   /**
    * @param {Event} e Message event object


### PR DESCRIPTION
Currently, we load on scroll - but the perceived load time is terrible. We've decided to load on page load instead. Also, we've switched out the desktop version of the dashboard because the first one was setting a default filter which we don't want.