### PR TITLE
adding polyfill for Object.entries for IE compatibility

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -59,9 +59,9 @@
     }
     if (!Object.entries) {
       Object.entries = function(obj) {
-        var ownProps = Object.keys(obj)
-        var i = ownProps.length;
-        var resArray = new Array(i);
+        const ownProps = Object.keys(obj);
+        const i = ownProps.length;
+        let resArray = new Array(i);
         while (i--) {
           resArray[i] = [ownProps[i], obj[ownProps[i]]];
         }

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -60,7 +60,7 @@
     if (!Object.entries) {
       Object.entries = function(obj) {
         const ownProps = Object.keys(obj);
-        const i = ownProps.length;
+        let i = ownProps.length;
         let resArray = new Array(i);
         while (i--) {
           resArray[i] = [ownProps[i], obj[ownProps[i]]];

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -57,6 +57,17 @@
     if (NodeList.prototype.forEach === undefined) {
       NodeList.prototype.forEach = Array.prototype.forEach;
     }
+    if (Object.prototype.entries === undefined) {
+      Object.prototype.entries = function(obj) {
+        var ownProps = Object.keys(obj)
+        var i = ownProps.length;
+        var resArray = new Array(i);
+        while (i--) {
+          resArray[i] = [ownProps[i], obj[ownProps[i]]];
+        }
+        return resArray;
+      };
+    }
   }
 
   /**

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -57,8 +57,8 @@
     if (NodeList.prototype.forEach === undefined) {
       NodeList.prototype.forEach = Array.prototype.forEach;
     }
-    if (Object.prototype.entries === undefined) {
-      Object.prototype.entries = function(obj) {
+    if (!Object.entries) {
+      Object.entries = function(obj) {
         var ownProps = Object.keys(obj)
         var i = ownProps.length;
         var resArray = new Array(i);


### PR DESCRIPTION
Adds polyfill for Object.entries, since it's not compatible with IE. Adapted from polyfill snippet on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries

It will be kind of a game of whack-a-mole with these kinds of things until we get everybody off of IE, and on to Edge at least. ¯\\\_(ツ)\_/¯